### PR TITLE
Don't attempt to load strict.pm etc. under RISC OS

### DIFF
--- a/testcode/test.pl
+++ b/testcode/test.pl
@@ -222,15 +222,15 @@
 #           * The 'for' statements do not include the 'my' which is expected on later
 #             perl version, as it is implicit in the earlier versions.
 #           * mkdir must always be called with an octal mode.
-if ($^O ne '' && $^O ne 'riscos')
-{
-    BEGIN {
-        eval "use warnings;";
-        eval "use strict;";
-    }
 
-    BEGIN {
-        eval "use Time::HiRes qw(time);";
+BEGIN {
+    if ($^O ne '' && $^O ne 'riscos')
+    {
+        require warnings;;
+        require strict;
+        require Time::HiRes;
+
+        Time::HiRes->import("time");
     }
 }
 


### PR DESCRIPTION
Previously, the code inside the BEGIN block would run on all OSs regardless. No error is seen if the modules are not available because the load happens inside an eval.